### PR TITLE
Add  option disableinprogressfilter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ To make the list of courses in the Moodle nav drawer complete again, you need to
                  $flatnavcourses[$course->id] = $course;
 ```
 
+Alternatively you can enable the setting ```disableinprogressfilter``` to override Moodle's internal filter.
+
 
 ### List length
 

--- a/lang/en/local_boostcoc.php
+++ b/lang/en/local_boostcoc.php
@@ -42,3 +42,6 @@ $string['setting_enablenotshowntechnicalhint'] = 'Technically, this is done by s
 $string['setting_enablenotshownperformancehint'] = 'Please note: If you enable this setting and have also enabled the setting <a href="/admin/search.php?query=navshowmycoursecategories">navshowmycoursecategories</a>, removing the course nodes takes more time and you should consider disabling the navshowmycoursecategories setting.';
 $string['setting_filterstatusheading'] = 'Filter status';
 $string['setting_generalfunctionalityheading'] = 'General functionality';
+$string['setting_disableinprogressfilter'] = 'Disable Moodle built-in in-progress filter';
+$string['setting_disableinprogressfilter_desc'] = 'Moodle\'s standard behavior is to only display in-progress courses in the \'My Courses\' navigation menu. Combined with the functionality of this plugin this may lead to confusing results, e.g. courses visible in the course overview  but not in \'My Course\'. Selecting this option disables Moodle\'s standard filter. NOTE: this option only works if the option <a href="/admin/search.php?query=enablenotshown">enablenotshown</a> is enabled.';
+$string['setting_disableinprogressfilter_technicalhint'] = 'Enabling this option overrides the attribute <code>showinflatnavigation</code> of course nodes before applying CoC filters. The performance pernalty should be negligible. ';

--- a/lib.php
+++ b/lib.php
@@ -47,6 +47,11 @@ function local_boostcoc_extend_navigation(global_navigation $navigation) {
     if ((isset($lbcocconfig->enablenotshown) && $lbcocconfig->enablenotshown == true) ||
             (isset($lbcocconfig->addactivefiltershint) && $lbcocconfig->addactivefiltershint == true)) {
         $mycoursesnode = $navigation->find('mycourses', global_navigation::TYPE_ROOTNODE);
+        if ((isset($lbcocconfig->disableinprogressfilter) && $lbcocconfig->disableinprogressfilter == true)) {
+            foreach ($mycoursesnode->children as $coursenode) {
+                $coursenode->showinflatnavigation = true;
+            }
+        }
     }
 
     // Check if admin wanted us to modify the mycourses list in Boost's nav drawer.

--- a/settings.php
+++ b/settings.php
@@ -46,6 +46,13 @@ if ($hassiteconfig) {
                         get_string('setting_enablenotshownperformancehint', 'local_boostcoc'),
                 0));
 
+        // Create enable not shown courses control widget.
+        $page->add(new admin_setting_configcheckbox('local_boostcoc/disableinprogressfilter',
+            get_string('setting_disableinprogressfilter', 'local_boostcoc', null, true),
+            get_string('setting_disableinprogressfilter_desc', 'local_boostcoc', null, true).'<br />'.
+            get_string('setting_disableinprogressfilter_technicalhint', 'local_boostcoc', null, true).'<br />',
+            0));
+
         // Add filter status heading.
         $page->add(new admin_setting_heading('local_boostcoc/filterstatusheading',
                 get_string('setting_filterstatusheading', 'local_boostcoc', null, true),


### PR DESCRIPTION
Hi Alex,

as discussed, this adds an option to override the moodle internal navigation filter in the plugin without core changes.

Cheers,
Dimitri.